### PR TITLE
fixed typo that was causing sort to not work correctly

### DIFF
--- a/src/listwidget/EqList.js
+++ b/src/listwidget/EqList.js
@@ -276,7 +276,7 @@ var EqList = function (params) {
       return;
     }
 
-    events.sort(_compareEvents || _this._compareEvents);
+    events.sort(_compareEvents || _this.compareEvents);
 
     for (i = 0; i < len; i++) {
       markup.push(_this.getEventMarkup(events[i]));
@@ -343,7 +343,7 @@ var EqList = function (params) {
    *
    * Gets the markup for one event. Default implementation creates a list item
    * and uses the ```getEventValue```, ```getEventTitle```,
-   * ```getEventSubtitle```, and ```getEventAside```. 
+   * ```getEventSubtitle```, and ```getEventAside```.
    *
    * @param e {Object}
    *      A single event feature from the raw GeoJSON response.


### PR DESCRIPTION
fixes usgs/earthquake-list-widget#12

- Fixed Typo that was causing events to not be sorted